### PR TITLE
Use Node 18 LTS / fix error cannot build docker file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM node:14.15-slim AS build
+FROM node:18-slim AS build
 RUN apt-get update && apt-get -y install python3 build-essential
 WORKDIR /app
 COPY . .
 RUN npm install
 
-FROM node:14.15-slim
+FROM node:18-slim
 RUN mkdir /data
 VOLUME /data
 COPY --from=build /app /app


### PR DESCRIPTION
Fixes the error during docker build:

0.655 Err:6 http://security.debian.org/debian-security stretch/updates/main amd64 Packages
0.655   404  Not Found [IP: 151.101.194.132 80]